### PR TITLE
Fixing opengraph for facebook compliance

### DIFF
--- a/src/classes/ImagePanel.php
+++ b/src/classes/ImagePanel.php
@@ -46,6 +46,9 @@
 
 class ImagePanel implements HTMLObject
 {
+
+    /// Header
+    public $header;
 	
 	/// Image object
 	private $image;
@@ -58,7 +61,6 @@ class ImagePanel implements HTMLObject
 	
 	/// Judge object
 	private $judge;
-
 
 	/**
 	 * Create ImagePanel
@@ -85,6 +87,13 @@ class ImagePanel implements HTMLObject
 			/// Create Comments object
 			$this->comments	=	new Comments($file);
 		}
+  
+        $root_url = "http".($_SERVER["HTTPS"]?"s":"")."://".$_SERVER["SERVER_NAME"];
+        $pageurl = $root_url.$_SERVER["REQUEST_URI"];
+        
+        $this->header = "<meta property=\"og:url\" content=\"".$pageurl."\"/>\n"
+            ."<meta property=\"og:title\" content=\"".File::a2r($file)."\"/>\n"
+            ."<meta property=\"og:image\" content=\"".$root_url."/?t=Thb&f=".urlencode(File::a2r($file))."\"/>\n";
 
 		/// Set the Judge
 		$this->judge 	=	new Judge($file);

--- a/src/classes/MainPage.php
+++ b/src/classes/MainPage.php
@@ -115,7 +115,7 @@ class MainPage extends Page
 	 * @author Thibaud Rohmer
 	 */
 	public function toHTML(){
-		$this->header();
+		$this->header($this->image_panel->header);
 		echo "<body>";
 
 		echo "<div id='container'>\n";		

--- a/src/classes/Page.php
+++ b/src/classes/Page.php
@@ -52,7 +52,7 @@ abstract class Page implements HTMLObject
 		 * @return void
 		 * @author Thibaud Rohmer
 		 */
-		public function header(){
+		public function header($head_content=NULL){
 			echo "<html>";
 			echo "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
 			echo "<head>\n";
@@ -92,6 +92,12 @@ abstract class Page implements HTMLObject
 				echo "<script src='inc/jquery.fileupload-ui.js'></script>\n";
 				echo "<script src='src/js/admin.js'></script>\n";
 			}
+
+            // Add specific head content if needed
+            if ($head_content)
+            {
+                echo $head_content;
+            }
 
 			echo "</head>";
 		}


### PR DESCRIPTION
Hi osi,

I have added opengraph meta tags so you can past a link to a public image on facebook and have the thumbnail of the image fetched by facebook to show the link.

This will also be useful for the facebook "like" button as the same meta tags will be used.

You can use facebook linter to verify my work ;)

Thanks,
Franck
