### PR TITLE
Fix Bug - performance problem with AdminStats

### DIFF
--- a/src/classes/AdminStats.php
+++ b/src/classes/AdminStats.php
@@ -61,7 +61,11 @@
  	 */
  	public function __construct(){
 
- 		/// Calculate number of users, etc...
+ 	}
+	
+	public function Calculate() {
+	
+		/// Calculate number of users, etc...
  		$this->stats['Users'] = sizeof(Account::findAll());
 
  		$this->stats['Groups'] = sizeof(Group::findAll());
@@ -80,10 +84,11 @@
  			$xml = simplexml_load_file($commentsfile);
  			$this->comments = $xml->children();
  		}
- 	}
+	
+	}
 
  	public function toHTML(){
-
+		self::Calculate() ;
  		echo "<div class='adminblock'>";
  		echo "<h3>Stats</h3>";
  		echo "<div>";


### PR DESCRIPTION
If you have several thousand photos. The class loading AdminStats a problem when you are logged in administrator.

The whole site is extremely slow because you instantiate this class in the class Admin (line 178 in admin.php)

I suggest you move the statistical calculation of the launch of the admin page
