### PR TITLE
[sorting] If "reverse_menu" is activated, also sort out the folder grid accordingly

### DIFF
--- a/src/classes/Board.php
+++ b/src/classes/Board.php
@@ -232,7 +232,9 @@ class Board implements HTMLObject
 				$this->boardfolders[] = $item;
 			}
 		}
-
+		if(Settings::$reverse_menu){
+			$this->boardfolders = array_reverse($this->boardfolders);
+		}
 	}
 
 


### PR DESCRIPTION
Hi Thibaud,

would you be interested in this commit, that'd fix #64 ?

Cheers,

--Seb
