### PR TITLE
fix #109 - Uploaders can now actually upload

### DIFF
--- a/src/classes/Infos.php
+++ b/src/classes/Infos.php
@@ -54,7 +54,7 @@ class Infos implements HTMLObject
 
 	public function __construct(){
 
-		if(CurrentUser::$admin){
+		if(CurrentUser::$admin || CurrentUser::$uploader){
 			$this->info = new AdminPanel();
 		}
 		
@@ -67,7 +67,7 @@ class Infos implements HTMLObject
 	}
 
 	public function toHTML(){
-		if(CurrentUser::$admin){
+		if(CurrentUser::$admin || CurrentUser::$uploader ){
 		$this->info->toHTML();
 		}
 		


### PR DESCRIPTION
The section generated by Infos.php wasn't displayed for the users defined as uploaders. This was preventing uploaders to create/rename folders, and most important, to upload.
