### PR TITLE
fix: users within the uploaders group were unable to upload files

### DIFF
--- a/src/classes/AdminPanel.php
+++ b/src/classes/AdminPanel.php
@@ -109,7 +109,9 @@ class AdminPanel
 
 	public function toHTML(){
 
-		//echo $this->infos;
+        if (CurrentUser::$uploader) {
+    		echo $this->infos;
+        }
 
 		if(CurrentUser::$admin){
 			echo $this->j->toHTML();


### PR DESCRIPTION
Since the new upload panel, users within the uploaders group cannot upload anymore.

I switched on back the old upload form only for these users.
