### PR TITLE
Fix password change in Account.php

### DIFF
--- a/src/classes/Account.php
+++ b/src/classes/Account.php
@@ -293,7 +293,7 @@ class Account extends Page
 		}
 
 		/// Edit attributes
-		if(isset($password) && sizeof($password) > 4 ){
+		if(isset($password) && strlen($password) > 4 ){
 			$acc->password = Account::password($password);
 		}
 


### PR DESCRIPTION
Account edition was checking new password's size badly: it used sizeof() instead strlen().

Without this fix, password changes are impossible, as sizeof($password) always equals to 1 whatever the string length is actually.
