### PR TITLE
Correcly display the Aperture

### DIFF
--- a/src/classes/Exif.php
+++ b/src/classes/Exif.php
@@ -109,7 +109,7 @@ class Exif implements HTMLObject
 		$this->wanted['Make'][]			=	'Make';
 		$this->wanted['Expo'][]			=	'ExposureTime';
 		$this->wanted['Focal Length'][]	=	'FocalLength';
-		$this->wanted['Aperture'][]		=	'ApertureValue';
+		$this->wanted['Aperture'][]		=	'FNumber';
 		$this->wanted['ISO'][]			=	'ISOSpeedRatings';
 		$this->wanted['Original Date'][]=	'DateTimeOriginal';
 	}
@@ -184,8 +184,8 @@ class Exif implements HTMLObject
 									break;
 			case 'FocalLength':		$v		=	$this->frac2float($raw_exif[$d])." mm";
 									break;
-			case 'ApertureValue':	if($a = number_format($this->frac2float($raw_exif[$d]),"1") > 0){
-										$v = "1/".$a;
+			case 'FNumber':	        if(($a = number_format($this->frac2float($raw_exif[$d]),"1")) > 0){
+										$v = "f".$a;
 									}else{
 										$v='Unknown';
 									}


### PR DESCRIPTION
I always get the same Aperture value in the right menu: "Aperture 1/1".

This is because of 2 bugs:
- PhotoShow use EXIF ApertureValue instead of FNumber
- the code is missing parenthesis: ``ìf (a = fct() > 0)`` should be ``if
  ((a = fct()) > 0)`` or a will be affected to the test ``fct() > 0`` so
  1 (or true).

For a sample image I have the EXIF data (returned by ``exif_read_data()``):
- COMPUTED.ApertureFNumber: f/10.0
- EXIF.FNumber: 10/1
- EXIF.ApertureValue: 6643856/1000000

The easiest would be to use the COMPUTED.ApertureFNumber value
returned by ``exif_read_data()`` but I did not succeed (I do not know PHP).
So my patch uses EXIF.FNumber and changes the display to be "f/10.0"