### PR TITLE
Do not add the $site_address in generated tokens

### DIFF
--- a/src/classes/GuestToken.php
+++ b/src/classes/GuestToken.php
@@ -281,7 +281,7 @@ class GuestToken extends Page
         }
 
         if (self::exist($key)){
-            $url = Settings::$site_address."?f=".urlencode(self::get_path($key))."&token=".$key;
+            $url = "?f=".urlencode(self::get_path($key))."&token=".$key;
         }
 
         return $url;


### PR DESCRIPTION
Let the web client add the protocol and site address.

The problem is that the protocol part of the URL is "http:" even for
sites in "https:"
My problem was that the Apache rewrite rule to redirect a http: page to
the https: equivalent corrupted the URL.

See bug #240 "Guest token does not work correctly for folders containing
accents" https://github.com/thibaud-rohmer/PhotoShow/issues/240