### PR TITLE
Prevent exception with file upload ui

### DIFF
--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -30,7 +30,7 @@
 
 
 function init_dropzone(){
-		$('.dropzone').fileUploadUI({
+		$('.dropzone:not(.fileUploadInitialized)').addClass('fileUploadInitialized').fileUploadUI({
 		uploadTable: 		$('#files'),
 		downloadTable: 		$('#files'),
 		buildUploadRow: 	function (files, index) {


### PR DESCRIPTION
Prevent exception 'Uncaught FileUpload with namespace file_upload already assigned to this element' when a file upload is performed
