### PR TITLE
Fix first accented character of folders stripped out

### DIFF
--- a/src/classes/BoardHeader.php
+++ b/src/classes/BoardHeader.php
@@ -60,7 +60,7 @@ class BoardHeader{
 	 */
 	public function __construct(){
 		$this->path 	=	urlencode(File::a2r(CurrentUser::$path));
-		$this->title 	=	is_dir(CurrentUser::$path)?basename(CurrentUser::$path):basename(dirname(CurrentUser::$path));
+		$this->title 	=	is_dir(CurrentUser::$path)?end(explode('/', CurrentUser::$path)):end(explode('/', dirname(CurrentUser::$path)));
 		$this->w 		= 	File::a2r(CurrentUser::$path);
 	}
 	

--- a/src/classes/Menu.php
+++ b/src/classes/Menu.php
@@ -82,7 +82,7 @@ class Menu implements HTMLObject
 		}
 
 		/// Set variables
-		$this->title = basename($dir);
+		$this->title = end(explode('/', $dir));
 		$this->webdir= urlencode(File::a2r($dir));
 		$this->path  = File::a2r($dir);
 


### PR DESCRIPTION
basename is not locale safe; when a folder starts with an accented
character, it is stripped.
This commit replaces basename for the left menu and the header.
It fixes issue #272.