### PR TITLE
Check rights for directory before searchDir executed - better perform…

### DIFF
--- a/src/classes/Board.php
+++ b/src/classes/Board.php
@@ -125,6 +125,8 @@ class Board implements HTMLObject
                 if ( $i > 9){
                     break;
                 }
+                if(!Judge::view($d))	//Dir is not accessible (rights) - ignore it for better performance 
+                    continue;
                 $img = Judge::searchDir($d, true);
                 if ($img)
                 {
@@ -170,6 +172,8 @@ class Board implements HTMLObject
 	 */
 	private function foldergrid(){
 		foreach($this->dirs as $d){
+			if(!Judge::view($d))	//Dir is not accessible (rights) - ignore it for better performance 
+				 continue;
 			$firstImg = Judge::searchDir($d);
 			if(!$firstImg){
 				if(CurrentUser::$admin){


### PR DESCRIPTION
Check rights for directory before searchDir executed - better performance with private folders.
Otherwise it check every dir and every file, it it's accessible - user has rights to read it - so it took long time with big numbers of files. And it's done twice.
This request check, if folder has right to read and if not, skip it.