### PR TITLE
Allows to download filenames with ' and "

### DIFF
--- a/src/classes/Account.php
+++ b/src/classes/Account.php
@@ -142,7 +142,7 @@ class Account extends Page
 		}
 
 
-		if( preg_match("/[^a-z0-9]/i", $login) || strlen($password) < 6){
+		if( preg_match("/[^a-z0-9.]/i", $login) || strlen($password) < 6){
 			return false;
 		}
 

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -372,7 +372,7 @@ class Provider
 			if(Judge::view($item)){
                                 // Use only the relative path of the filename
 				$item = str_replace('//', '/', $item);
-				$itemsString.=" '".substr($item,$delimPosition+1)."'";
+				$itemsString.=" \"".str_replace( '"' , '\"' , substr( $item , $delimPosition + 1 ) )."\"";
 			}
 		}
 


### PR DESCRIPTION
It's now possible to download a ZIP archive which contains filenames (directories) which have characters ' and ".
Thus for example, it will allow to download a ZIP file of: http://www.photoshow-gallery.com/demo/?f=France%2FIle+d%27Arz.
Tested with a Debian Jessie GNU/Linux server.