### PR TITLE
Use mp4 instead of WebM for video

### DIFF
--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -148,7 +148,58 @@ class Provider
         header("Cache-Control: maxage=".$expires);
         header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
         header('Content-type: video/mp4');
-        readfile($path);
+        $fp = @fopen($path, 'rb');
+
+        $size   = filesize($path); // File size
+        $length = $size;           // Content length
+        $start  = 0;               // Start byte
+        $end    = $size - 1;       // End byte
+
+        header("Accept-Ranges: 0-$length");
+        if (isset($_SERVER['HTTP_RANGE'])) {
+
+            $c_start = $start;
+            $c_end   = $end;
+
+            list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);
+            if (strpos($range, ',') !== false) {
+                header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                header("Content-Range: bytes $start-$end/$size");
+                exit;
+            }
+            if ($range == '-') {
+                $c_start = $size - substr($range, 1);
+            }else{
+                $range  = explode('-', $range);
+                $c_start = $range[0];
+                $c_end   = (isset($range[1]) && is_numeric($range[1])) ? $range[1] : $size;
+            }
+            $c_end = ($c_end > $end) ? $end : $c_end;
+            if ($c_start > $c_end || $c_start > $size - 1 || $c_end >= $size) {
+                header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                header("Content-Range: bytes $start-$end/$size");
+                exit;
+            }
+            $start  = $c_start;
+            $end    = $c_end;
+            $length = $end - $start + 1;
+            fseek($fp, $start);
+            header('HTTP/1.1 206 Partial Content');
+	    }
+        header("Content-Range: bytes $start-$end/$size");
+        header("Content-Length: ".$length);
+
+        $buffer = 1024 * 8;
+	    while(!feof($fp) && ($p = ftell($fp)) <= $end) {
+
+            if ($p + $buffer > $end) {
+                $buffer = $end - $p + 1;
+            }
+            set_time_limit(0);
+            echo fread($fp, $buffer);
+            flush();
+	    }
+        fclose($fp);
     }
 
     public static function thumb($file)
@@ -337,8 +388,61 @@ class Provider
                     readfile($path);
                 }
             }else{
+                $fp = @fopen($path, 'rb');
+
+                $size   = filesize($path); // File size
+                $length = $size;           // Content length
+                $start  = 0;               // Start byte
+                $end    = $size - 1;       // End byte
+
                 header('Content-type: video/mp4');
-                readfile($path);
+                header("Accept-Ranges: 0-$length");
+                if (isset($_SERVER['HTTP_RANGE'])) {
+
+                    $c_start = $start;
+                    $c_end   = $end;
+
+                    list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);
+                    if (strpos($range, ',') !== false) {
+                        header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                        header("Content-Range: bytes $start-$end/$size");
+                        exit;
+                    }
+                    if ($range == '-') {
+                        $c_start = $size - substr($range, 1);
+                    }else{
+                        $range  = explode('-', $range);
+                        $c_start = $range[0];
+                        $c_end   = (isset($range[1]) && is_numeric($range[1])) ? $range[1] : $size;
+                    }
+                    $c_end = ($c_end > $end) ? $end : $c_end;
+                    if ($c_start > $c_end || $c_start > $size - 1 || $c_end >= $size) {
+                        header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                        header("Content-Range: bytes $start-$end/$size");
+                        exit;
+                    }
+                    $start  = $c_start;
+                    $end    = $c_end;
+                    $length = $end - $start + 1;
+                    fseek($fp, $start);
+                    header('HTTP/1.1 206 Partial Content');
+                }
+                header("Content-Range: bytes $start-$end/$size");
+                header("Content-Length: ".$length);
+
+
+                $buffer = 1024 * 8;
+                while(!feof($fp) && ($p = ftell($fp)) <= $end) {
+
+                    if ($p + $buffer > $end) {
+                        $buffer = $end - $p + 1;
+                    }
+                    set_time_limit(0);
+                    echo fread($fp, $buffer);
+                    flush();
+                }
+
+                fclose($fp);
             }
         }
     }

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -129,7 +129,7 @@ class Provider
 
         $basefile	= 	new File($file);
         $basepath	=	File::a2r($file);
-        $path	=	Settings::$thumbs_dir.dirname($basepath)."/".$basefile->name.".webm";	
+        $path	=	Settings::$thumbs_dir.dirname($basepath)."/".$basefile->name.".mp4";
 
         if(!isset($path) || !file_exists($path)){
             error_log('ERROR/Provider::Video: path:'.$path.' does not exist, using '.$file);
@@ -147,7 +147,7 @@ class Provider
         header("Etag: $etag"); 
         header("Cache-Control: maxage=".$expires);
         header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
-        header('Content-type: video/webm');
+        header('Content-type: video/mp4');
         readfile($path);
     }
 

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -326,8 +326,8 @@ class Provider
 				header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
 			}
 
-	        header('Content-type: image/jpeg');
             if(File::Type($path)=="Image"){
+                header('Content-type: image/jpeg');
             	readfile($path);
             	return;
                 try {
@@ -337,6 +337,7 @@ class Provider
                     readfile($path);
                 }
             }else{
+                header('Content-type: video/mp4');
                 readfile($path);
             }
         }

--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -149,7 +149,7 @@ class Settings extends Page
 	static public $ffmpeg_path 		=	"/usr/bin/ffmpeg";
 	
 	///FFMPEG Option
-	static public $ffmpeg_option	=	"-threads 4 -c:v libx264 -c:a libmp3lame";
+	static public $ffmpeg_option	=	"-threads 4 -vcodec libx264 -acodec libfdk_aac";
 
 
 	/**

--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -149,7 +149,7 @@ class Settings extends Page
 	static public $ffmpeg_path 		=	"/usr/bin/ffmpeg";
 	
 	///FFMPEG Option
-	static public $ffmpeg_option	=	"-threads 4 -qmax 40 -acodec libvorbis -ab 128k -ar 41000 -vcodec libvpx";	
+	static public $ffmpeg_option	=	"-threads 4 -c:v libx264 -c:a libmp3lame";
 
 
 	/**

--- a/src/classes/Video.php
+++ b/src/classes/Video.php
@@ -314,7 +314,7 @@ class Video implements HTMLObject
 	 * @author Cédric Levasseur
 	 */
 	public function toHTML(){	
-        self::VideoDiv('',400,true);
+        self::VideoDiv(320,'',true);
 	}
 
 }

--- a/src/classes/Video.php
+++ b/src/classes/Video.php
@@ -164,7 +164,7 @@ class Video implements HTMLObject
 	
 	
 	/**
-	 * Asynchronous Convert all Video format to video/webm
+	 * Asynchronous Convert all Video format to video/mp4
 	 *   
 	 * Use ffmpeg for conversion
 	 * @return void
@@ -179,13 +179,13 @@ class Video implements HTMLObject
 
         $file_file	       = new File($file);
         $thumb_path_no_ext = Settings::$thumbs_dir.dirname(File::a2r($file))."/".$file_file->name;
-        $thumb_path_webm   = $thumb_path_no_ext.'.webm';	
+        $thumb_path_mp4   = $thumb_path_no_ext.'.mp4';
         $thumb_path_jpg    = $thumb_path_no_ext.'.jpg';	
 
 
         // Check if thumb folder exist
-        if(!file_exists(dirname($thumb_path_webm))){
-            @mkdir(dirname($thumb_path_webm),0755,true);
+        if(!file_exists(dirname($thumb_path_mp4))){
+            @mkdir(dirname($thumb_path_mp4),0755,true);
         }
 
 
@@ -202,17 +202,17 @@ class Video implements HTMLObject
 
         if (self::NoJob($file))// We check that first to allow the clean of old job files
         {
-            if (!file_exists($thumb_path_webm) || filectime($file) > filectime($thumb_path_webm)){
-                if ($file_file->extension !="webm") {
-                    ///Convert video to webm format in Thumbs folder
+            if (!file_exists($thumb_path_mp4) || filectime($file) > filectime($thumb_path_mp4)){
+                if ($file_file->extension !="mp4") {
+                    ///Convert video to mp4 format in Thumbs folder
                     //TODO: Max job limit
-                    $u = Settings::$ffmpeg_path.' -i "'.$file.'" '.Settings::$ffmpeg_option.' -y "'.$thumb_path_webm.'"';		
+                    $u = Settings::$ffmpeg_path.' -i "'.$file.'" '.Settings::$ffmpeg_option.' -y "'.$thumb_path_mp4.'"';
                     $pid = self::ExecInBackground($u);
                     self::CreateJob($file, $pid);
                 }
                 else {
-                    ///Copy original webm video to Thumbs folder
-                    copy($file,$thumb_path_webm);
+                    ///Copy original mp4 video to Thumbs folder
+                    copy($file,$thumb_path_mp4);
                 }
             }
         }
@@ -300,7 +300,7 @@ class Video implements HTMLObject
         if ($control) {
             $c = ' controls="controls"';
         }
-        echo '<video'.$wh.$c.'><source src="?t=Vid&f='.$this->fileweb.'" type="video/webm" />';
+        echo '<video'.$wh.$c.'><source src="?t=Vid&f='.$this->fileweb.'" type="video/mp4"/>';
         echo 'Your browser does not support the video tag.<br />';
         echo 'Please upgrade your brower or Download the codec <a href="http://tools.google.com/dlpage/webmmf">Download</a>';
         echo '</video>';


### PR DESCRIPTION
H.264 + AAC + MP4 is mode widely supported than VP8 (WebM).
This PR makes video playing working on more browsers and mobile devices.

Remaining to do :
* Use intelligent algorithm to adapt video player width and height to display
* If source video is already an mp4, detect audio and video codec in order to see if a copy is enough, or if we need to reencode (for instance mobile Safari only accept audio AAC codec)