### PR TITLE
Prevent to have anamorphic thumbnails

### DIFF
--- a/src/stylesheets/structure.css
+++ b/src/stylesheets/structure.css
@@ -173,7 +173,7 @@ div.directory .dirname
 
 div.directory img{
 	width:100%;
-	max-height: 150px;
+	max-height: auto;
 }
 
 /* Linear Panel */


### PR DESCRIPTION
This little CSS change avoids to have thumbnail images anamorphic regardless of the screen width like it's already the case for http://www.photoshow-gallery.com/demo/