### PR TITLE
Improve 304 response so that browser will cache on subsequent calls

### DIFF
--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -441,6 +441,9 @@ class Provider
         $if_modified_since = @$_SERVER['HTTP_IF_MODIFIED_SINCE'];
         $last_modified_time = filemtime($path);
         if (!empty($if_modified_since) && (strtotime($if_modified_since) == $last_modified_time)) {
+	    $expires = 240;
+	    header("Cache-Control: private; max-age=" . $expires);
+	    header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $last_modified_time) . ' GMT', true, 304);
             exit();
         }

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -440,18 +440,19 @@ class Provider
     public static function HTTP_Cache($path) {
         $if_modified_since = @$_SERVER['HTTP_IF_MODIFIED_SINCE'];
         $last_modified_time = filemtime($path);
+        $expires = Settings::$cache_max_age;
+
+        header("Pragma: private");
+        header("Cache-Control: private; max-age=" . $expires);
+        header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
+
         if (!empty($if_modified_since) && (strtotime($if_modified_since) == $last_modified_time)) {
-	    $expires = 240;
-	    header("Cache-Control: private; max-age=" . $expires);
-	    header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $last_modified_time) . ' GMT', true, 304);
             exit();
         }
+
         header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $last_modified_time) . ' GMT');
         //header("ETag: " . md5_file($file));
-        $expires = Settings::$cache_max_age;
-        header("Cache-Control: private; max-age=" . $expires);
-        header('Expires: ' . gmdate('D, d M Y H:i:s', time()+$expires) . ' GMT');
     }
 
 	/**


### PR DESCRIPTION
In the 304 response for images, PhotoShow sends the default "no-cache" Cache-Control header, causing the browser to omit the If-Modified-Since header.  This fixes that, so that it will cache every time.

The value "240" is included in case the browser does not "do the right thing" and use the expiry date from the original request.

Tested on "Mozilla Firefox for Ubuntu version 56"