### PR TITLE
Exiftran for seamless photos rotations

### DIFF
--- a/docker/debian/07-wheezy/Dockerfile
+++ b/docker/debian/07-wheezy/Dockerfile
@@ -16,12 +16,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	php5-fpm \
 	php5-gd \
 	libgd2-xpm \
-	supervisor
-    
+	supervisor \
+	exiftran
+
 RUN git clone https://github.com/thibaud-rohmer/PhotoShow.git /var/www/PhotoShow
 RUN cd /var/www/PhotoShow && sed -i -e 's/$config->photos_dir.\+/$config->photos_dir = "\/opt\/PhotoShow\/Photos";/' config.php
 RUN cd /var/www/PhotoShow && sed -i -e 's/$config->ps_generated.\+/$config->ps_generated = "\/opt\/PhotoShow\/generated";/' config.php
-    
+
 RUN sed -i -e 's/^\(\[supervisord\]\)$/\1\nnodaemon=true/' /etc/supervisor/supervisord.conf
 ADD supervisor-photoshow.conf /etc/supervisor/conf.d/photoshow.conf
 

--- a/docker/debian/09-stretch/Dockerfile
+++ b/docker/debian/09-stretch/Dockerfile
@@ -17,12 +17,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	php-gd \
 	php-xml \
 	libgd-dev \
-	supervisor
-    
+	supervisor \
+	exiftran
+
 RUN git clone https://github.com/thibaud-rohmer/PhotoShow.git /var/www/PhotoShow
 RUN cd /var/www/PhotoShow && sed -i -e 's/$config->photos_dir.\+/$config->photos_dir = "\/opt\/PhotoShow\/Photos";/' config.php
 RUN cd /var/www/PhotoShow && sed -i -e 's/$config->ps_generated.\+/$config->ps_generated = "\/opt\/PhotoShow\/generated";/' config.php
-    
+
 RUN sed -i -e 's/^\(\[supervisord\]\)$/\1\nnodaemon=true/' /etc/supervisor/supervisord.conf
 ADD supervisor-photoshow.conf /etc/supervisor/conf.d/photoshow.conf
 

--- a/inc/loc/default.ini
+++ b/inc/loc/default.ini
@@ -39,6 +39,7 @@ video_comment	= "PhotoShow only displays videos in WebM. You can set the encodin
 encode_video	= "Encode Video"
 ffmpeg_path	= "FFmpeg path"
 ffmpeg_option	= "Encoding option"
+image = "Photos"
 image_comment	= "Rotate images accordingly to Exif information losslessly."
 exiftran_path = "Exiftran path"
 

--- a/inc/loc/default.ini
+++ b/inc/loc/default.ini
@@ -39,6 +39,8 @@ video_comment	= "PhotoShow only displays videos in WebM. You can set the encodin
 encode_video	= "Encode Video"
 ffmpeg_path	= "FFmpeg path"
 ffmpeg_option	= "Encoding option"
+image_comment	= "Rotate images accordingly to Exif information losslessly."
+exiftran_path = "Exiftran path"
 
 [account]
 createaccount	= "Create Account"

--- a/inc/loc/default.ini
+++ b/inc/loc/default.ini
@@ -40,7 +40,8 @@ encode_video	= "Encode Video"
 ffmpeg_path	= "FFmpeg path"
 ffmpeg_option	= "Encoding option"
 image = "Photos"
-image_comment	= "Rotate images accordingly to Exif information losslessly."
+rotate_image = "Rotate photos"
+image_comment	= "Lossless rotatation of photos accordingly to Exif information."
 exiftran_path = "Exiftran path"
 
 [account]

--- a/src/classes/AdminUpload.php
+++ b/src/classes/AdminUpload.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file implements the class AdminUpload.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE:
- * 
+ *
  * This file is part of PhotoShow.
  *
  * PhotoShow is free software: you can redistribute it and/or modify
@@ -46,13 +46,13 @@
 
  	/**
  	 * Upload files on the server
- 	 * 
+ 	 *
  	 * @author Thibaud Rohmer
  	 */
  	public function upload(){
 
  		$allowedExtensions = array("tiff","jpg","jpeg","gif","png");
-		
+
 		/// Just to be really sure ffmpeg is enabled - necessary to generate thumbnail jpg and webm
 		if (Settings::$encode_video) {
 			array_push($allowedExtensions,"flv","mov","mpg","mp4","ogv","mts","3gp","webm");
@@ -60,14 +60,14 @@
 
 		$already_set_rights = false;
 
- 		/// Just to be really sure... 
+ 		/// Just to be really sure...
  		if( !(CurrentUser::$admin || CurrentUser::$uploader) ){
  			return;
  		}
 
  		/// Set upload path
  		$path = stripslashes(File::r2a($_POST['path']));
- 		
+
  		/// Create dir and update upload path if required
  		if(strlen(stripslashes($_POST['newdir']))>0 && !strpos(stripslashes($_POST['newdir']),'..')){
 
@@ -82,7 +82,7 @@
  				if(isset($_POST['public'])){
  					Judge::edit($path);
  				}else{
- 					Judge::edit($path,$_POST['users'],$_POST['groups']);					
+ 					Judge::edit($path,$_POST['users'],$_POST['groups']);
  				}
  			}
  			$already_set_rights = true;
@@ -96,18 +96,18 @@
 
 				// Name of the stored file
 		        $tmp_name = $_FILES["images"]["tmp_name"][$key];
-		
+
 				// Name on the website
 		        $name = $_FILES["images"]["name"][$key];
-				
+
 				$info = pathinfo($name);
 				$base_name =  mb_basename($name,'.'.$info['extension']);
-		
+
 				// Check filetype
 				if(!in_array(strtolower($info['extension']),$allowedExtensions)){
 					continue;
 				}
-				
+
 				// Rename until this name isn't taken
 				$i=1;
 				while(file_exists("$path/$name")){
@@ -119,6 +119,7 @@
 		        if(move_uploaded_file($tmp_name, "$path/$name")){
 		    	//	$done .= "Successfully uploaded $name";
 				Video::FastEncodeVideo("$path/$name");
+        Image::AutoRotateImage("$path/$name");
 		        }
 
 		        /// Setup rights
@@ -126,7 +127,7 @@
  					if(isset($_POST['public'])){
  						Judge::edit("$path/$name");
  					}else{
- 						Judge::edit("$path/$name",$_POST['users'],$_POST['groups']);					
+ 						Judge::edit("$path/$name",$_POST['users'],$_POST['groups']);
  					}
  				}
 			}

--- a/src/classes/AdminUpload.php
+++ b/src/classes/AdminUpload.php
@@ -116,11 +116,11 @@
 				}
 
 				// Save the files
-		        if(move_uploaded_file($tmp_name, "$path/$name")){
-		    	//	$done .= "Successfully uploaded $name";
-      				Video::FastEncodeVideo("$path/$name");
-              Image::AutoRotateImage("$path/$name");
-		        }
+        if(move_uploaded_file($tmp_name, "$path/$name")){
+    	//	$done .= "Successfully uploaded $name";
+  				Video::FastEncodeVideo("$path/$name");
+          Image::AutoRotateImage("$path/$name");
+        }
 
 		        /// Setup rights
 	 			if(!$already_set_rights && !isset($_POST['inherit'])){

--- a/src/classes/AdminUpload.php
+++ b/src/classes/AdminUpload.php
@@ -100,12 +100,12 @@
 				// Name on the website
 		        $name = $_FILES["images"]["name"][$key];
 
-				$info = pathinfo($name);
-				$base_name =  mb_basename($name,'.'.$info['extension']);
+  				$info = pathinfo($name);
+  				$base_name =  mb_basename($name,'.'.$info['extension']);
 
-				// Check filetype
-				if(!in_array(strtolower($info['extension']),$allowedExtensions)){
-					continue;
+  				// Check filetype
+  				if(!in_array(strtolower($info['extension']),$allowedExtensions)){
+  					continue;
 				}
 
 				// Rename until this name isn't taken
@@ -118,8 +118,8 @@
 				// Save the files
 		        if(move_uploaded_file($tmp_name, "$path/$name")){
 		    	//	$done .= "Successfully uploaded $name";
-				Video::FastEncodeVideo("$path/$name");
-        Image::AutoRotateImage("$path/$name");
+      				Video::FastEncodeVideo("$path/$name");
+              Image::AutoRotateImage("$path/$name");
 		        }
 
 		        /// Setup rights

--- a/src/classes/Image.php
+++ b/src/classes/Image.php
@@ -128,8 +128,9 @@ class Image implements HTMLObject
 			if(!File::Type($file) || File::Type($file) != "Image"){
 					return;
 			}
-
-			exec("`which exiftran ` -ai ".escapeshellarg($file)." 2>&1", $output);
+			if(Settings::rotate_image){
+				exec("`which exiftran ` -ai ".escapeshellarg($file)." 2>&1", $output);
+			}
 	}
 
 

--- a/src/classes/Image.php
+++ b/src/classes/Image.php
@@ -128,7 +128,7 @@ class Image implements HTMLObject
 					return;
 			}
 			if(Settings::$rotate_image){
-				exec(Settings::$exiftran_path."-ai ".escapeshellarg($file)." 2>&1", $output);
+				exec(Settings::$exiftran_path." -ai ".escapeshellarg($file)." 2>&1", $output);
 			}
 	}
 

--- a/src/classes/Image.php
+++ b/src/classes/Image.php
@@ -118,10 +118,9 @@ class Image implements HTMLObject
 	}
 
 	/**
-	 * Compute the dimension of a video using ffmpeg
+	 * Rotate image with exiftran
 	 *
-	 * @return the dimension in a array of int
-	 * @author Franck Royer
+	 * @author Guglielmo Saggiorato
 	 */
 	public function AutoRotateImage($file){
 
@@ -129,7 +128,7 @@ class Image implements HTMLObject
 					return;
 			}
 			if(Settings::$rotate_image){
-				exec(Setings::$exiftran_path."-ai ".escapeshellarg($file)." 2>&1", $output);
+				exec(Settings::$exiftran_path."-ai ".escapeshellarg($file)." 2>&1", $output);
 			}
 	}
 

--- a/src/classes/Image.php
+++ b/src/classes/Image.php
@@ -128,8 +128,8 @@ class Image implements HTMLObject
 			if(!File::Type($file) || File::Type($file) != "Image"){
 					return;
 			}
-			if(Settings::rotate_image){
-				exec("`which exiftran ` -ai ".escapeshellarg($file)." 2>&1", $output);
+			if(Settings::$rotate_image){
+				exec(Setings::$exiftran_path."-ai ".escapeshellarg($file)." 2>&1", $output);
 			}
 	}
 

--- a/src/classes/Image.php
+++ b/src/classes/Image.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file implements the class Image.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE:
- * 
+ *
  * This file is part of PhotoShow.
  *
  * PhotoShow is free software: you can redistribute it and/or modify
@@ -47,38 +47,38 @@ class Image implements HTMLObject
 {
 	/// URLencoded version of the relative path to file
 	static public $fileweb;
-	
+
 	/// URLencoded version of the relative path to directory containing file
 	private $dir;
-	
+
 	/// Width of the image
 	private $x;
-	
+
 	/// Height of the image
 	private $y;
 
 	/// Force big image or not
 	private $t;
-	
-	
+
+
 	/**
 	 * Create image
 	 *
-	 * @param string $file 
+	 * @param string $file
 	 * @author Thibaud Rohmer
 	 */
 	public function __construct($file=NULL,$forcebig = false){
-		
+
 		/// Check file type
 		if(!isset($file) || !File::Type($file) || File::Type($file) != "Image")
 			return;
-		
+
 		/// Set relative path (url encoded)
 		$this->fileweb	=	urlencode(File::a2r($file));
-		
+
 		/// Set relative path to parent dir (url encoded)
 		$this->dir	=	urlencode(dirname(File::a2r($file)));
-		
+
 		/// Get image dimensions
 		list($this->x,$this->y)=getimagesize($file);
 
@@ -97,8 +97,42 @@ class Image implements HTMLObject
 			}
 		}
 	}
-	
-	
+
+	/**
+	 * Create Asynchrone Execution (compatibles Linux/Windows)
+	 *
+	 * @param string $file
+     * @return pid of the executed command (only linux)
+	 * @author C�dric Levasseur/Franck Royer
+	 */
+	public function ExecInBackground($cmd) {
+		error_log('DEBUG/Video: Background Execution : '.$cmd,0);
+        $pid = 0;
+		if (substr(php_uname(), 0, 7) == "Windows"){
+		   pclose(popen('start /b '.$cmd.' 2>&1', 'r'));
+		} else {
+		    exec($cmd . " > /dev/null 2>&1 & echo $!", $output);
+            $pid = intval($output[0]);
+		}
+        return $pid;
+	}
+
+	/**
+	 * Compute the dimension of a video using ffmpeg
+	 *
+	 * @return the dimension in a array of int
+	 * @author Franck Royer
+	 */
+	public function AutoRotateImage($file){
+
+			if(!File::Type($file) || File::Type($file) != "Image"){
+					return;
+			}
+
+			exec("`which exiftran ` -ai ".escapeshellarg($file)." 2>&1", $output);
+	}
+
+
 	/**
 	 * Display the image on the website
 	 *
@@ -115,7 +149,7 @@ class Image implements HTMLObject
 		echo 	"';>";
 
 		echo "<input type='hidden' id='imageurl' value='?t=Big&f=$this->fileweb'>";
-		echo 	"<a href='?f=$this->dir'>"; 
+		echo 	"<a href='?f=$this->dir'>";
 		echo 	"<img src='inc/img.png' style='opacity:0;' alt=\"\">";
 		echo 	"</a>";
 		echo	"</div>";

--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -420,6 +420,7 @@ class Settings extends Page
 	    "encode_video",
 	    "ffmpeg_path",
 	    "ffmpeg_option",
+			"rotate_image",
 			"exiftran_path",
 	    "user_theme",
 	    "thumbs_size",

--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -578,7 +578,6 @@ class Settings extends Page
 		echo "<label><input type='checkbox' name='rotate_image' $c> ".Settings::_("settings","rotate_image")."</label>\n";
 		echo "</div>";
 
-
 		/// ExifTran Path
 		echo "<div class='pure-control-group'>
 					<label>".Settings::_("settings","exiftran_path")."</label>


### PR DESCRIPTION
Hi,

I implemented the option to rotate the photos accordingly to their exif tags using `exiftran` (which does lossless rotation, as a plus). The rotation is done once for all when the photo is uploaded.

Changes:
1. `Image.php`: I added the code in Image.php to handle the rotation
2. `AdminUpload.php`: one function call just below the video conversion call
3. `Settings.php`: Added settings configuration
4. `default.ini`: added the new strings
5. `Dockerfile` for both docker images are updated with the new dependency (exiftran, indeed)

Use case:
I share the folder `Photos` with a `dlna` server which is not able to rotate the photos for the players.
Plus, in my setup the patch in #312 (in #322) does not seem to work at all. 

I am by no means a php programmer, but I hope my code is good enough to be merged.
Let me know your comments :)
