### PR TITLE
fixed orientation generation of cached images (small ones and thumbs)

### DIFF
--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -233,7 +233,7 @@ class Provider
             $thumb->q = Settings::$quality_mini;
 
             if (File::Type($file) == 'Image' && Provider::get_orientation_degrees($file) != 0) {
-                $thumb->ra = 360 - Provider::get_orientation_degrees($file);
+                $thumb->ra = Provider::get_orientation_degrees($file);
             }
 
             $thumb->GenerateThumbnail();
@@ -281,7 +281,7 @@ class Provider
             $thumb->q = Settings::$quality_small;
 
             if (File::Type($file) == 'Image' && Provider::get_orientation_degrees($file) != 0) {
-                $thumb->ra = 360 - Provider::get_orientation_degrees($file);
+                $thumb->ra = Provider::get_orientation_degrees($file);
             }
 
             $thumb->GenerateThumbnail();

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -233,9 +233,7 @@ class Provider
             $thumb->q = Settings::$quality_mini;
 
             if (File::Type($file) == 'Image' && Provider::get_orientation_degrees($file) != 0) {
-                $thumb->SourceImageToGD();
                 $thumb->ra = 360 - Provider::get_orientation_degrees($file);
-                $thumb->Rotate();
             }
 
             $thumb->GenerateThumbnail();
@@ -283,9 +281,7 @@ class Provider
             $thumb->q = Settings::$quality_small;
 
             if (File::Type($file) == 'Image' && Provider::get_orientation_degrees($file) != 0) {
-                $thumb->SourceImageToGD();
                 $thumb->ra = 360 - Provider::get_orientation_degrees($file);
-                $thumb->Rotate();
             }
 
             $thumb->GenerateThumbnail();


### PR DESCRIPTION
The images are almost in the right representation now. The generated files (small ones and thumbs) do have the right angle now, but they still need to be mirrored horizontally.
This should be a fix for issue #286.
I tested it with the images from here (https://magnushoff.com/jpeg-orientation.html).

The only problem left (for me) is this:
If the generated small image (?t=Img&...) has exif orientation information (3-8), because it's width and height is lower than 1200, the image doesn't get rotated by the browser.