### PR TITLE
Provider::small generates files into Settings::$small_dir

### DIFF
--- a/src/classes/AdminStats.php
+++ b/src/classes/AdminStats.php
@@ -72,7 +72,7 @@
 
  		$this->stats['Items'] = sizeof(Menu::list_files(Settings::$photos_dir,true));
 
- 		$this->stats['Generated items'] = sizeof(Menu::list_files(Settings::$thumbs_dir,true));
+ 		$this->stats['Generated items'] = sizeof(Menu::list_files(Settings::$thumbs_dir,true)) + sizeof(Menu::list_files(Settings::$small_dir,true));
 
  		$this->stats['Albums'] = sizeof(Menu::list_dirs(Settings::$photos_dir,true));
 

--- a/src/classes/Provider.php
+++ b/src/classes/Provider.php
@@ -256,16 +256,12 @@ class Provider
     {
         require_once dirname(__FILE__).'/../phpthumb/phpthumb.class.php';
 
-        $basefile = new File($file);
-        $basepath = File::a2r($file);
-        $webimg = dirname($basepath) . "/" . $basefile->name . "_small." . $basefile->extension;
-
         list($x,$y) = getimagesize($file);
         if($x <= 1200 && $y <= 1200){
             return $file;
         }
 
-        $path = File::r2a($webimg, Settings::$thumbs_dir);
+        $path = File::r2a(File::a2r($file),Settings::$small_dir);
 
         /// Create smaller image
         if (!file_exists($path) || filectime($file) > filectime($path)) {

--- a/src/classes/Settings.php
+++ b/src/classes/Settings.php
@@ -51,6 +51,9 @@ class Settings extends Page
 	/// Directory where the thumbs are stored
 	static public $thumbs_dir;
 
+	/// Directory where the small images are stored
+	static public $small_dir;
+
 	/// Directory where the configuration files are stored
 	static public $conf_dir;
 
@@ -212,6 +215,7 @@ class Settings extends Page
 		/// Setup variables
 		Settings::$photos_dir	=	$config->photos_dir;
 		Settings::$thumbs_dir	=	$config->ps_generated."/Thumbs/";
+		Settings::$small_dir    =   $config->ps_generated."/Small/";
 		Settings::$conf_dir		=	$config->ps_generated."/Conf/";
 		Settings::$admin_settings_file = $config->ps_generated."/Conf/admin_settings.ini";
 
@@ -252,6 +256,12 @@ class Settings extends Page
 		if(!file_exists(Settings::$thumbs_dir)){
 			if(! @mkdir(Settings::$thumbs_dir,0750,true)){
 				throw new Exception("PS_GENERATED dir '".Settings::$thumbs_dir."' doesn't exist or doesn't have the good rights.");
+			}
+		}
+
+		if(!file_exists(Settings::$small_dir)){
+			if(! @mkdir(Settings::$small_dir,0750,true)){
+				throw new Exception("PS_GENERATED dir '".Settings::$small_dir."' doesn't exist or doesn't have the good rights.");
 			}
 		}
 


### PR DESCRIPTION
With this customization I'm able to have the Settings::$photos_dir readonly and also cache the small images.