### PR TITLE
Based onto Alpine Docker image allows to reduce image size by 2.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,45 @@
-FROM debian:stretch-slim
+FROM alpine:3.10.1
+
 MAINTAINER CYOSP <cyosp@cyosp.com>
 
-RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && apt install -yq \
-	--no-install-recommends \
-	ca-certificates \
-	zip \
-	git \
-	nginx \
-	php-fpm \
-	php-gd \
-	php-xml \
-	libgd-dev \
-	supervisor \
-	exiftran \
+RUN apk upgrade \
+    && apk add \
+      ca-certificates \
+      git \
+      zip \
+      nginx \
+      php7-session \
+      php7-fpm \
+      php7-gd \
+      php7-xml \
+      php7-simplexml \
+      php7-exif \
+      gd-dev \
+      supervisor \
+      fbida-exiftran \
 	&& git clone https://github.com/thibaud-rohmer/PhotoShow.git /var/www/PhotoShow \
-	&& apt remove -yq \
-       	ca-certificates \
-       	git \
-    && apt autoremove -yq
+	&& apk del ca-certificates git
 
-RUN mkdir -p /opt/PhotoShow/Photos /opt/PhotoShow/generated && chown -R www-data:www-data /opt/PhotoShow/Photos /opt/PhotoShow/generated
+RUN deluser xfs
+RUN adduser -u 33 -D -S -G www-data www-data
 
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+RUN rm /etc/nginx/conf.d/default.conf
+ADD nginx.conf /etc/nginx/conf.d/photoshow.conf
+RUN mkdir -p /run/nginx /var/run/php
+
+RUN sed -i -e 's/^.\+daemonize.\+$/daemonize = no/' /etc/php7/php-fpm.conf
+RUN rm /etc/php7/php-fpm.d/www.conf
+ADD fpm.conf /etc/php7/php-fpm.d/photoshow.conf
+
+RUN mkdir -p /opt/PhotoShow/Photos /opt/PhotoShow/generated
+RUN chown -R www-data:www-data /opt/PhotoShow/Photos /opt/PhotoShow/generated
 RUN sed -i -e 's/$config->photos_dir.\+/$config->photos_dir = "\/opt\/PhotoShow\/Photos";/' /var/www/PhotoShow/config.php
 RUN sed -i -e 's/$config->ps_generated.\+/$config->ps_generated = "\/opt\/PhotoShow\/generated";/' /var/www/PhotoShow/config.php
 
-RUN rm -f /etc/nginx/sites-enabled/default && echo "daemon off;" >> /etc/nginx/nginx.conf && mkdir -p /var/run/php
-ADD nginx.conf /etc/nginx/conf.d/photoshow.conf
-
-RUN sed -i -e 's/^.\+daemonize.\+$/daemonize = no/' /etc/php/7.0/fpm/php-fpm.conf
-ADD fpm.conf /etc/php/7.0/fpm/pool.d/photoshow.conf
-
-RUN sed -i -e 's/^\(\[supervisord\]\)$/\1\nnodaemon=true/' /etc/supervisor/supervisord.conf
-ADD supervisor.conf /etc/supervisor/conf.d/photoshow.conf
+RUN sed -i -e 's/^\(\[supervisord\]\)$/\1\nnodaemon=true/' /etc/supervisord.conf
+ADD supervisor.conf /etc/supervisor.d/photoshow.ini
+RUN mkdir -p "/var/log/supervisor"
 
 VOLUME ["/opt/PhotoShow", "/var/log"]
 EXPOSE 80

--- a/docker/fpm.conf
+++ b/docker/fpm.conf
@@ -1,4 +1,18 @@
 [www]
+user = www-data
+group = www-data
+
+listen = /var/run/php/php7.0-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+
+pm = dynamic
+pm.start_servers = 1
+pm.max_children = 5
+pm.min_spare_servers = 1
+pm.max_spare_servers = 2
+
 php_value[upload_max_filesize] = 14M
 php_value[post_max_size] = 14M
 php_value[memory_limit] = 96M

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -6,7 +6,7 @@ stopsignal=6
 autorestart=true
 
 [program:phpfpm]
-command=/usr/sbin/php-fpm7.0
+command=/usr/sbin/php-fpm7
 stdout_logfile=/var/log/supervisor/%(program_name)s.stdout
 stderr_logfile=/var/log/supervisor/%(program_name)s.stderr
 stopsignal=6


### PR DESCRIPTION
Hi @thibaud-rohmer,

This new pull request allows to reduce again generated Docker image size by around a 2.4  factor.
No PhotoShow functionality is lost in a 116MB image.
It's possible by switching Docker base image from stretch-slim to alpine.

Best regards,
CYOSP